### PR TITLE
(refactor) - add display name tracking to our exchange

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
   "name": "@urql/devtools",
   "version": "1.0.0",
-  "main": "dist/index.js",
+  "main": "index.js",
   "types": "dist/index.d.ts",
   "description": "The exchange for use with Urql Devtools",
-  "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -25,12 +24,15 @@
   },
   "homepage": "https://github.com/FormidableLabs/urql-devtools-exchange#readme",
   "devDependencies": {
+    "@types/node": "^12.7.1",
     "graphql": "^14.4.2",
     "prettier": "^1.18.2",
+    "react": "^16.9.0",
     "typescript": "^3.5.3",
     "urql": "^1.2.0"
   },
   "peerDependencies": {
+    "react": ">= 16.8.0",
     "urql": ">= 1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@urql/devtools",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "description": "The exchange for use with Urql Devtools",
   "scripts": {

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -36,12 +36,26 @@ export const devtoolsExchange: Exchange = ({ client, forward }) => {
   return ops$ => {
     return pipe(
       ops$,
+      tap(addOperationContext),
       tap(handleOperation),
       forward,
       tap(handleOperation)
     );
   };
 };
+
+const addOperationContext = (op: Operation): Operation => {
+  return {
+    ...op,
+    context: {
+      ...op.context,
+      meta: {
+        ...op.context.meta,
+        source: getDisplayName(),
+      }
+    }
+  }
+}
 
 /** Handle operation or response from stream. */
 const handleOperation = <T extends Operation | OperationResult>(op: T) => {
@@ -73,13 +87,6 @@ const parseStreamData = <T extends Operation | OperationResult>(op: T) => {
 
   // Outgoing operation
   if ("operationName" in op) {
-    (op as Operation).context = {
-      ...(op as Operation).context,
-      meta: {
-        ...(op as Operation).context.meta,
-        source: getDisplayName()
-      }
-    };
     return {
       type: "operation",
       data: op,

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -1,4 +1,4 @@
-import { pipe, tap, toPromise } from "wonka";
+import { map, pipe, tap, toPromise } from "wonka";
 import {
   Exchange,
   Client,
@@ -36,7 +36,7 @@ export const devtoolsExchange: Exchange = ({ client, forward }) => {
   return ops$ => {
     return pipe(
       ops$,
-      tap(addOperationContext),
+      map(addOperationContext),
       tap(handleOperation),
       forward,
       tap(handleOperation)

--- a/src/getDisplayName.ts
+++ b/src/getDisplayName.ts
@@ -1,0 +1,40 @@
+import * as React from "react";
+
+const {
+  ReactCurrentOwner: CurrentOwner
+} = (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+
+// Is the Fiber a FunctionComponent, ClassComponent, or IndeterminateComponent
+const isComponentFiber = (fiber: void | { tag: number }) =>
+  fiber && (fiber.tag === 0 || fiber.tag === 1 || fiber.tag === 2);
+
+// Is the component one of ours (just a heuristic to avoid circular dependencies or flags)
+const isInternalComponent = (Component: { name: string }) =>
+  Component.name === "Query" ||
+  Component.name === "Mutation" ||
+  Component.name === "Subscription";
+
+export const getDisplayName = (): string => {
+  let source = "Component";
+
+  // Check whether the CurrentOwner is set
+  const owner = CurrentOwner.current;
+  if (owner !== null && isComponentFiber(owner)) {
+    let Component = owner.type;
+
+    // If this is one of our own components then check the parent
+    if (
+      isInternalComponent(Component) &&
+      isComponentFiber(owner._debugOwner)
+    ) {
+      Component = owner._debugOwner.type;
+    }
+
+    // Get the Component's name if it has one
+    if (typeof Component === "function") {
+      source = Component.displayName || Component.name || source;
+    }
+  }
+
+  return source;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@types/node@^12.7.1":
+  version "12.7.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.1.tgz#3b5c3a26393c19b400844ac422bd0f631a94d69d"
+  integrity sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -29,7 +34,7 @@ iterall@^1.2.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -46,7 +51,7 @@ prettier@^1.18.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
-prop-types@^15.6.0:
+prop-types@^15.6.0, prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -59,6 +64,15 @@ react-is@^16.8.1:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
+react@^16.9.0:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
+  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
 
 typescript@^3.5.3:
   version "3.5.3"


### PR DESCRIPTION
Instead of using `useDevtoolsContext` in urql we've opted to move this here, this makes the urql codebase a bit easier and moves this concern to the devtools. This makes for a bit less magic going on.

Related: https://github.com/FormidableLabs/urql/pull/387