### PR TITLE
(feat) - offer the option to use this in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <img alt="logo" src="https://raw.githubusercontent.com/FormidableLabs/urql-devtools/master/src/assets/icon.svg?sanitize=true" />
-  <h1>Urql Devtools Exchange</h1>
-  
+  <h1>urql devtools exchange</h1>
+
   <a href="https://spectrum.chat/urql">
     <img alt="Spectrum badge" src="https://withspectrum.github.io/badge/badge.svg" />
   </a>
@@ -10,41 +10,42 @@
   <br />
 </div>
 
-The official devtools exchange for use with [Urql Devtools chrome extension](https://github.com/FormidableLabs/urql-devtools).
+The official devtools exchange for use with [urql devtools chrome extension](https://github.com/FormidableLabs/urql-devtools).
 
 ### Requirements
 
-- [Urql](https://github.com/FormidableLabs/urql) _v1.2.0_ (or later)
-- [Urql Devtools chrome extension](https://github.com/FormidableLabs/urql-devtools)
+- [urql](https://github.com/FormidableLabs/urql) _v1.2.0_ (or later)
+- [urql devtools chrome extension](https://github.com/FormidableLabs/urql-devtools)
 
 ### Usage
 
 Install the devtools exchange
 
 ```sh
-# Yarn
+# yarn
 yarn add -D @urql/devtools
 
-# Npm
+# npm
 npm i -D @urql/devtools
 ```
 
-Add the devtools exchange to your Urql client
+Add the devtools exchange to your urql client
 
 ```tsx
 // ...
-import {
-  cacheExchange,
-  createClient,
-  dedupExchange,
-  fetchExchange
-} from "urql";
+import { defaultExchanges, createClient } from "urql";
 import { devtoolsExchange } from "@urql/devtools";
 
 // ...
 const client = createClient({
   url: "http://localhost:3001/graphql",
-  exchanges: [dedupExchange, devtoolsExchange, cacheExchange, fetchExchange]
+  exchanges: [
+    // replacing devtools with a passthrough exchange for production environments
+    process.env.NODE_ENV !== "production"
+      ? devtoolsExchange
+      : ({ forward }) => forward,
+    ...defaultExchanges
+  ]
 });
 ```
 

--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -17,7 +17,7 @@ import {
 import { getDisplayName } from "./utils";
 
 export const devtoolsExchange: Exchange = ({ client, forward }) => {
-  if (process.env.NODE_ENV === "production" || typeof window === "undefined") {
+  if (typeof window === "undefined") {
     return ops$ =>
       pipe(
         ops$,


### PR DESCRIPTION
I think this is the correct way to tackle https://github.com/FormidableLabs/urql-devtools/issues/48 now that `useDevtoolsContext` is integrated into this library. A user is actively encouraged to do the following:

```js
const client = createClient({
  exchanges: [
    process.env.NODE_ENV !== 'production' && devToolsExchange,
    ...rest
  ].filter(Boolean)
})
```

If the consumer of the application doens't want it enabled in production it won't be and the bundle size won't be affected since terser will eliminate the code.