### PR TITLE
(fix) - use correct check for non-browser env

### DIFF
--- a/src/exchange.ts
+++ b/src/exchange.ts
@@ -17,7 +17,7 @@ import {
 import { getDisplayName } from "./utils";
 
 export const devtoolsExchange: Exchange = ({ client, forward }) => {
-  if (process.env.NODE_ENV === "production" || typeof window === undefined) {
+  if (process.env.NODE_ENV === "production" || typeof window === "undefined") {
     return ops$ =>
       pipe(
         ops$,


### PR DESCRIPTION
Ran into issues trying to use the exchange in a NextJS application (SSR), this should fix it.