### PR TITLE
make react internals usage optional to support preact

### DIFF
--- a/src/utils/getDisplayName.ts
+++ b/src/utils/getDisplayName.ts
@@ -1,8 +1,6 @@
 import * as React from 'react';
 
-const {
-  ReactCurrentOwner: CurrentOwner,
-} = (React as any).__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED;
+const CurrentOwner = (React as any)?.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED?.ReactCurrentOwner;
 
 // Is the Fiber a FunctionComponent, ClassComponent, or IndeterminateComponent
 const isComponentFiber = (fiber: void | { tag: number }) =>
@@ -18,8 +16,9 @@ export const getDisplayName = (): string => {
   let source = 'Component';
 
   // Check whether the CurrentOwner is set
-  const owner = CurrentOwner.current;
-  if (owner !== null && isComponentFiber(owner)) {
+  const owner = CurrentOwner?.current;
+
+  if (owner && isComponentFiber(owner)) {
     let Component = owner.type;
 
     // If this is one of our own components then check the parent


### PR DESCRIPTION
Hi there,

I have a project where I'm using URQL with Preact, which works really well together apart from an issue with URQL devtools exchange.
It breaks as it relies on `__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED` to read the name of the initiator component when a GraphQL request is sent, but unfortunately that internal variable is not available with Preact.

As I see this is the only usage and in the current implementation it's optional as well, as the `getDisplayName` function already checks the presence of `ReactCurrentOwner.owner`.

With these minor adjustments the devtools works fine with Preact, apart from displaying `Component` as fallback for the component name in the _Events_ tab.