### PR TITLE
Update `@urql/core` and `graphql` dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/node": "^12.12.39",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
-    "@urql/core": "^1.15.0",
+    "@urql/core": "^2.0.0",
     "babel-plugin-closure-elimination": "^1.3.1",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
     "eslint": "^7.1.0",
@@ -86,7 +86,7 @@
     "wonka": ">= 4.0.9"
   },
   "peerDependencies": {
-    "@urql/core": ">= 1.14.0",
-    "graphql": ">= 0.11.0"
+    "@urql/core": ">= 2.0.0",
+    "graphql": ">= 15.0.0"
   }
 }


### PR DESCRIPTION
Update the `@urql/core` dependency to `^2.0.0` as any new project using URQL will incur an console error while it's still funcitonal.

Also updated the `graphql` peerDependency since the `devDependency` already stated `^15.0.0`